### PR TITLE
fix: runtime error in Angular bundles

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -1,37 +1,23 @@
-export default class support {
-    static get base64() {
-        return true;
-    }
+const support = {
+    base64: true,
+    array: true,
+    string: true,
+    nodebuffer: false,
+    nodestream: false,
 
-    static get array() {
-        return true;
-    }
-
-    static get string() {
-        return true;
-    }
-
-    static get nodebuffer() {
-        return false;
-    }
-
-    static get nodestream() {
-        return false;
-    }
-
-    static get arraybuffer() {
+    get arraybuffer() {
         return typeof ArrayBuffer !== "undefined" && typeof Uint8Array !== "undefined";
-    }
+    },
 
     // Returns true if JSZip can read/generate Uint8Array, false otherwise.
-    static get uint8array() {
+    get uint8array() {
         return typeof Uint8Array !== "undefined";
-    }
+    },
 
-    static get blob() {
+    get blob() {
         return blob();
     }
-}
+};
 
 let blob = function() {
     let supported;
@@ -52,3 +38,5 @@ let blob = function() {
     blob = () => supported;
     return supported;
 };
+
+export default support;


### PR DESCRIPTION
The `support` class stops working in optimized Angular bundles. Replaced with a plain object instead.

Reported for Angular v7 in [ticket 1475218](https://supportheroes.telerik.com/ticket/1475218).

/cc @svetq 